### PR TITLE
Use Respective poll_interval From Config

### DIFF
--- a/lib/util.py
+++ b/lib/util.py
@@ -219,9 +219,13 @@ class Daemon:
         self.stop()
         self.start()
 
-    def get_poll_interval(self, c_site):
-        poll_interval = \
-            self.config['crits']['sites'][c_site]['api']['poll_interval']
+    def get_poll_interval(self, tool, site):
+        if tool == 'crits':
+            poll_interval = \
+                self.config[tool]['sites'][site]['api']['poll_interval']
+        elif tool == 'edge':
+            poll_interval = \
+                self.config[tool]['sites'][site]['taxii']['poll_interval']            
         return(poll_interval)
 
     def run(self):
@@ -244,7 +248,7 @@ class Daemon:
                                                      dest=e_site,
                                                      direction='c2e')
                     last_run = last_run.replace(tzinfo=pytz.utc)
-                    poll_interval = self.get_poll_interval(c_site)
+                    poll_interval = self.get_poll_interval('crits', c_site)
                     if now >= \
                        last_run + datetime.timedelta(seconds=poll_interval):
                         self.logger.info('initiating crits=>edge sync between '
@@ -266,7 +270,7 @@ class Daemon:
                                                      dest=c_site,
                                                      direction='e2c')
                     last_run = last_run.replace(tzinfo=pytz.utc)
-                    poll_interval = self.get_poll_interval(e_site)
+                    poll_interval = self.get_poll_interval('edge', e_site)
                     if now >= \
                        last_run + datetime.timedelta(seconds=poll_interval):
                         self.logger.info('initiating edge=>crits sync between '


### PR DESCRIPTION
The "get_poll_interval" function was always grabbing the CRITs poll_interval from config.
If the user changed the site name from "localhost" to something else in config.yaml (like I did), then a KeyError would occur because the poll_interval for CRITs is under "api" while for Edge it's under "taxii".

Hopefully this is the intended functionality.